### PR TITLE
go.pl: Support ##channels, &bitlbee, *znc_module

### DIFF
--- a/scripts196/go.pl
+++ b/scripts196/go.pl
@@ -47,7 +47,7 @@ sub cmd_go
 	$chan =~ s/ *//g;
 	foreach my $w (Irssi::windows) {
 		my $name = $w->get_active_name();
-		if ($name =~ /^#?\Q${chan}\E/) {
+		if ($name =~ /^(##?|\&|\*)?\Q${chan}\E/) {
 			$w->set_active();
 			return;
 		}


### PR DESCRIPTION
This improves the regex matching for other kinds of open windows / channels.
